### PR TITLE
Allow stopping the playback of a waveform

### DIFF
--- a/Adafruit_DRV2605.cpp
+++ b/Adafruit_DRV2605.cpp
@@ -81,6 +81,10 @@ void Adafruit_DRV2605::go() {
   writeRegister8(DRV2605_REG_GO, 1);
 }
 
+void Adafruit_DRV2605::stop() {
+  writeRegister8(DRV2605_REG_GO, 0);
+}
+
 void Adafruit_DRV2605::setMode(uint8_t mode) {
   writeRegister8(DRV2605_REG_MODE, mode);
 }

--- a/Adafruit_DRV2605.h
+++ b/Adafruit_DRV2605.h
@@ -80,6 +80,7 @@ class Adafruit_DRV2605 {
   void setWaveform(uint8_t slot, uint8_t w);
   void selectLibrary(uint8_t lib);
   void go(void);
+  void stop(void);
   void setMode(uint8_t mode);
   void setRealtimeValue(uint8_t rtp);
   // Select ERM (Eccentric Rotating Mass) or LRA (Linear Resonant Actuator) vibration motor


### PR DESCRIPTION
This feature is useful when a waveform playback is triggered by an external event that may be superseded by another event while the original waveform playback is still in progress.The datasheet for the controller states that writing a zero to the GO register during the playback of the waveform will abort the playback. A proposed new method stop() implements this functionality.
