### PR TITLE
Auto calibrate, pwmPassthrough, violent vibration 

### DIFF
--- a/Adafruit_DRV2605.cpp
+++ b/Adafruit_DRV2605.cpp
@@ -44,25 +44,21 @@ boolean Adafruit_DRV2605::begin() {
   Wire.begin();
   // uint8_t id = readRegister8(DRV2605_REG_STATUS);
   //Serial.print("Status 0x"); Serial.println(id, HEX);
-  
-  writeRegister8(DRV2605_REG_MODE, 0x00); // out of standby
+  autoCalibration();
   
   writeRegister8(DRV2605_REG_RTPIN, 0x00); // no real-time-playback
   
   writeRegister8(DRV2605_REG_WAVESEQ1, 1); // strong click
   writeRegister8(DRV2605_REG_WAVESEQ2, 0);
   
-  writeRegister8(DRV2605_REG_OVERDRIVE, 0); // no overdrive
-  
   writeRegister8(DRV2605_REG_SUSTAINPOS, 0);
   writeRegister8(DRV2605_REG_SUSTAINNEG, 0);
   writeRegister8(DRV2605_REG_BREAK, 0);
   writeRegister8(DRV2605_REG_AUDIOMAX, 0x64);
   
-  // ERM open loop
-  
   // turn off N_ERM_LRA
-  writeRegister8(DRV2605_REG_FEEDBACK, readRegister8(DRV2605_REG_FEEDBACK) & 0x7F);
+  uint8_t calVal = readRegister8(DRV2605_REG_FEEDBACK) & 0x03;
+  writeRegister8(DRV2605_REG_FEEDBACK, (readRegister8(DRV2605_REG_FEEDBACK) & 0x7C) | calVal);
   // turn on ERM_OPEN_LOOP
   writeRegister8(DRV2605_REG_CONTROL3, readRegister8(DRV2605_REG_CONTROL3) | 0x20);
   return true;
@@ -70,33 +66,70 @@ boolean Adafruit_DRV2605::begin() {
 
 boolean Adafruit_DRV2605::pwmPassthrough() {
   Wire.begin();
-  // uint8_t id = readRegister8(DRV2605_REG_STATUS);
-  //Serial.print("Status 0x"); Serial.println(id, HEX);
-  
-  writeRegister8(DRV2605_REG_MODE, 0x00); // out of standby
-  
-  writeRegister8(DRV2605_REG_RTPIN, 0x00); // no real-time-playback
-  
-  writeRegister8(DRV2605_REG_WAVESEQ1, 1); // strong click
-  writeRegister8(DRV2605_REG_WAVESEQ2, 0);
-  
-  writeRegister8(DRV2605_REG_OVERDRIVE, 0); // no overdrive
-  
-  writeRegister8(DRV2605_REG_SUSTAINPOS, 0);
-  writeRegister8(DRV2605_REG_SUSTAINNEG, 0);
-  writeRegister8(DRV2605_REG_BREAK, 0);
-  writeRegister8(DRV2605_REG_AUDIOMAX, 0x64);
-  
-  // ERM open loop
-  
-  // turn off N_ERM_LRA
-  writeRegister8(DRV2605_REG_FEEDBACK, readRegister8(DRV2605_REG_FEEDBACK) & 0x7F);
-  // turn on ERM_OPEN_LOOP
-  writeRegister8(DRV2605_REG_CONTROL3, readRegister8(DRV2605_REG_CONTROL3) | 0x20);
-  
+
+  autoCalibration();
+
+  uint8_t calVal = readRegister8(DRV2605_REG_FEEDBACK) & 0x03;
+  writeRegister8(DRV2605_REG_FEEDBACK, (readRegister8(DRV2605_REG_FEEDBACK) & 0x7C) );
+
   setMode(DRV2605_MODE_PWMANALOG);
-  writeRegister8(DRV2605_REG_CONTROL3, 0x03);
+  writeRegister8(DRV2605_REG_CONTROL3, 0x00);
   return true;
+}
+
+void Adafruit_DRV2605::autoCalibration() {
+  Serial.println("Starting Auto-Calibration...\n");
+
+  writeRegister8(DRV2605_REG_MODE, 0x00); // out of standby
+
+  writeRegister8(DRV2605_REG_RATEDV, 0xFF); // 5V Rated Voltage
+
+  writeRegister8(DRV2605_REG_CLAMPV, 0xFF); // 5.5V Overdrive Voltage
+
+  writeRegister8(DRV2605_REG_FEEDBACK, 0xB6);
+
+  writeRegister8(DRV2605_REG_CONTROL1, 0x13);
+
+  writeRegister8(DRV2605_REG_CONTROL2, 0xF5);
+
+  writeRegister8(DRV2605_REG_CONTROL3, 0x80);
+
+  setMode(1); // calibrate
+
+  go();
+
+  uint8_t diag_results = (readRegister8(DRV2605_REG_STATUS) & 0x08);
+
+  volatile uint8_t goBit = (readRegister8(DRV2605_REG_GO) & 0x01);
+  while (goBit != 0)
+  {
+    goBit = (readRegister8(DRV2605_REG_GO) & 0x01);
+  }
+
+  if (diag_results == 0x00)
+  {
+    Serial.println("Auto-Calibration was successful: ");
+  }
+  else
+  {
+    Serial.println("Auto-Calibration Failed.");
+    return;
+  }
+
+  //Save these values to EEPROM reloading at boot cycle or repeat auto-cal
+
+  uint8_t ACalComp = readRegister8(DRV2605_REG_AUTOCALCOMP);
+  uint8_t ACalBEMF = readRegister8(DRV2605_REG_AUTOCALEMP);
+  uint8_t BEMFGain = readRegister8(DRV2605_REG_FEEDBACK & 0x03);
+
+  Serial.print("ACalComp"); 
+  Serial.print(": 0x"); Serial.println(ACalComp, HEX);  
+
+  Serial.print("ACalBEMF"); 
+  Serial.print(": 0x"); Serial.println(ACalBEMF, HEX);  
+  Serial.print("BEMFGain"); 
+  Serial.print(": 0x"); Serial.println(BEMFGain, HEX);  
+  Serial.println();
 }
 
 void Adafruit_DRV2605::setWaveform(uint8_t slot, uint8_t w) {
@@ -134,8 +167,8 @@ uint8_t Adafruit_DRV2605::readRegister8(uint8_t reg) {
     Wire.requestFrom((byte)DRV2605_ADDR, (byte)1);
     x = Wire.read();
 
-  //  Serial.print("$"); Serial.print(reg, HEX); 
-  //  Serial.print(": 0x"); Serial.println(x, HEX);
+   // Serial.print("$"); Serial.print(reg, HEX); 
+   // Serial.print(": 0x"); Serial.println(x, HEX);
   
   return x;
 }
@@ -162,6 +195,3 @@ void Adafruit_DRV2605::useLRA ()
 {
   writeRegister8(DRV2605_REG_FEEDBACK, readRegister8(DRV2605_REG_FEEDBACK) | 0x80);
 }
-
-
-

--- a/Adafruit_DRV2605.cpp
+++ b/Adafruit_DRV2605.cpp
@@ -42,7 +42,7 @@ Adafruit_DRV2605::Adafruit_DRV2605() {
 /**************************************************************************/
 boolean Adafruit_DRV2605::begin() {
   Wire.begin();
-  uint8_t id = readRegister8(DRV2605_REG_STATUS);
+  // uint8_t id = readRegister8(DRV2605_REG_STATUS);
   //Serial.print("Status 0x"); Serial.println(id, HEX);
   
   writeRegister8(DRV2605_REG_MODE, 0x00); // out of standby
@@ -65,7 +65,37 @@ boolean Adafruit_DRV2605::begin() {
   writeRegister8(DRV2605_REG_FEEDBACK, readRegister8(DRV2605_REG_FEEDBACK) & 0x7F);
   // turn on ERM_OPEN_LOOP
   writeRegister8(DRV2605_REG_CONTROL3, readRegister8(DRV2605_REG_CONTROL3) | 0x20);
+  return true;
+}
 
+boolean Adafruit_DRV2605::pwmPassthrough() {
+  Wire.begin();
+  // uint8_t id = readRegister8(DRV2605_REG_STATUS);
+  //Serial.print("Status 0x"); Serial.println(id, HEX);
+  
+  writeRegister8(DRV2605_REG_MODE, 0x00); // out of standby
+  
+  writeRegister8(DRV2605_REG_RTPIN, 0x00); // no real-time-playback
+  
+  writeRegister8(DRV2605_REG_WAVESEQ1, 1); // strong click
+  writeRegister8(DRV2605_REG_WAVESEQ2, 0);
+  
+  writeRegister8(DRV2605_REG_OVERDRIVE, 0); // no overdrive
+  
+  writeRegister8(DRV2605_REG_SUSTAINPOS, 0);
+  writeRegister8(DRV2605_REG_SUSTAINNEG, 0);
+  writeRegister8(DRV2605_REG_BREAK, 0);
+  writeRegister8(DRV2605_REG_AUDIOMAX, 0x64);
+  
+  // ERM open loop
+  
+  // turn off N_ERM_LRA
+  writeRegister8(DRV2605_REG_FEEDBACK, readRegister8(DRV2605_REG_FEEDBACK) & 0x7F);
+  // turn on ERM_OPEN_LOOP
+  writeRegister8(DRV2605_REG_CONTROL3, readRegister8(DRV2605_REG_CONTROL3) | 0x20);
+  
+  setMode(DRV2605_MODE_PWMANALOG);
+  writeRegister8(DRV2605_REG_CONTROL3, 0x03);
   return true;
 }
 

--- a/Adafruit_DRV2605.h
+++ b/Adafruit_DRV2605.h
@@ -75,7 +75,7 @@ class Adafruit_DRV2605 {
 
   Adafruit_DRV2605(void);
   boolean begin(void);  
-  boolean pwmPassthrough();
+  // boolean pwmPassthrough(uint16_t, uint16_t);
 
   void writeRegister8(uint8_t reg, uint8_t val);
   uint8_t readRegister8(uint8_t reg);
@@ -90,6 +90,8 @@ class Adafruit_DRV2605 {
   void useERM();
   void useLRA();
   void autoCalibration();
+  void autoCalibration(uint16_t, uint16_t);
  private:
 
 };
+

--- a/Adafruit_DRV2605.h
+++ b/Adafruit_DRV2605.h
@@ -65,6 +65,7 @@
 #define DRV2605_REG_CONTROL2 0x1C
 #define DRV2605_REG_CONTROL3 0x1D
 #define DRV2605_REG_CONTROL4 0x1E
+#define DRV2605_REG_CONTROL5 0x1F
 #define DRV2605_REG_VBAT 0x21
 #define DRV2605_REG_LRARESON 0x22
 
@@ -74,6 +75,7 @@ class Adafruit_DRV2605 {
 
   Adafruit_DRV2605(void);
   boolean begin(void);  
+  boolean pwmPassthrough();
 
   void writeRegister8(uint8_t reg, uint8_t val);
   uint8_t readRegister8(uint8_t reg);
@@ -87,7 +89,7 @@ class Adafruit_DRV2605 {
   // The default is ERM, which is more common
   void useERM();
   void useLRA();
-
+  boolean calibrate();
  private:
 
 };

--- a/Adafruit_DRV2605.h
+++ b/Adafruit_DRV2605.h
@@ -89,7 +89,6 @@ class Adafruit_DRV2605 {
   // The default is ERM, which is more common
   void useERM();
   void useLRA();
-  boolean calibrate();
  private:
 
 };

--- a/Adafruit_DRV2605.h
+++ b/Adafruit_DRV2605.h
@@ -89,7 +89,7 @@ class Adafruit_DRV2605 {
   // The default is ERM, which is more common
   void useERM();
   void useLRA();
+  void autoCalibration();
  private:
 
 };
-

--- a/examples/passthrough/passthrough.ino
+++ b/examples/passthrough/passthrough.ino
@@ -1,0 +1,30 @@
+#include <Wire.h>
+#include "Adafruit_DRV2605.h"
+
+#define PWM_PIN 5
+
+Adafruit_DRV2605 drv;
+int pwmValue = 0; 
+int increments = 1;
+
+void setup() {
+  Serial.begin(9600);
+  Serial.println("PWM Passthrough Test");
+  drv.pwmPassthrough();
+}
+
+void loop() {
+  // can find sweet spots by knowing the PWM values whilst the motor vibrates
+  Serial.print("PWM Value: ");
+  Serial.println(pwmValue);
+  
+  analogWrite(PWM_PIN, pwmValue);
+
+  pwmValue = pwmValue + increments;
+
+  if (pwmValue <= 0 || pwmValue >= 255) {
+    increments = -increments;
+  }
+  
+  delay(30);
+}

--- a/examples/passthrough/passthrough.ino
+++ b/examples/passthrough/passthrough.ino
@@ -4,13 +4,17 @@
 #define PWM_PIN 5
 
 Adafruit_DRV2605 drv;
-int pwmValue = 0; 
+int pwmValue = 254; 
 int increments = 1;
 
 void setup() {
   Serial.begin(9600);
   Serial.println("PWM Passthrough Test");
   drv.pwmPassthrough();
+
+  //if you're on teensy, 
+  //it's a good idea to use this function that adjusts the pwm frequency
+  //analogWriteFrequency(PWM_PIN, 15000);// PWM Freq for motor   
 }
 
 void loop() {
@@ -22,9 +26,8 @@ void loop() {
 
   pwmValue = pwmValue + increments;
 
-  if (pwmValue <= 0 || pwmValue >= 255) {
+  if (pwmValue <= 0 || pwmValue >= 255) 
     increments = -increments;
-  }
   
   delay(30);
 }


### PR DESCRIPTION
Added auto calibration function.

This means the motor vibrates much more compared to before, note there have been a bunch of forum posts complaining about this drv2605 being 'too weak', this fixes that. 

Changed begin to take into account the new values found from the calibrator, and removed the no_overdrive.

Changed pwmPassthrough, fixing a bug and optimising it further.
