### PR TITLE
Add option to provide a different Wire object

### DIFF
--- a/Adafruit_DRV2605.cpp
+++ b/Adafruit_DRV2605.cpp
@@ -22,7 +22,7 @@
  * @section license License
  *
  * MIT license, all text above must be included in any redistribution.
- * 
+ *
  */
 /**************************************************************************/
 
@@ -53,12 +53,35 @@ Adafruit_DRV2605::Adafruit_DRV2605() {
 
 /**************************************************************************/
 /*!
+  @brief Setup HW using the default Wire
+  @return Return value from init()
+*/
+/**************************************************************************/
+boolean Adafruit_DRV2605::begin() {
+  _wire = &Wire;
+  return init();
+}
+
+/**************************************************************************/
+/*!
+  @brief Setup HW using a different Wire
+  @param theWire Pointer to a TwoWire object
+  @return Return value from init()
+*/
+/**************************************************************************/
+boolean Adafruit_DRV2605::begin(TwoWire *theWire) {
+  _wire = theWire;
+  return init();
+}
+
+/**************************************************************************/
+/*!
   @brief  Setup the HW
   @return Always true
 */
 /**************************************************************************/
-boolean Adafruit_DRV2605::begin() {
-  Wire.begin();
+boolean Adafruit_DRV2605::init() {
+  _wire->begin();
   uint8_t id = readRegister8(DRV2605_REG_STATUS);
   //Serial.print("Status 0x"); Serial.println(id, HEX);
 
@@ -171,11 +194,11 @@ uint8_t Adafruit_DRV2605::readRegister8(uint8_t reg) {
   uint8_t x;
 
   // use i2c
-  Wire.beginTransmission(DRV2605_ADDR);
-  Wire.write((byte)reg);
-  Wire.endTransmission();
-  Wire.requestFrom((byte)DRV2605_ADDR, (byte)1);
-  x = Wire.read();
+  _wire->beginTransmission(DRV2605_ADDR);
+  _wire->write((byte)reg);
+  _wire->endTransmission();
+  _wire->requestFrom((byte)DRV2605_ADDR, (byte)1);
+  x = _wire->read();
 
   //  Serial.print("$"); Serial.print(reg, HEX);
   //  Serial.print(": 0x"); Serial.println(x, HEX);
@@ -192,10 +215,10 @@ uint8_t Adafruit_DRV2605::readRegister8(uint8_t reg) {
 /**************************************************************************/
 void Adafruit_DRV2605::writeRegister8(uint8_t reg, uint8_t val) {
   // use i2c
-  Wire.beginTransmission(DRV2605_ADDR);
-  Wire.write((byte)reg);
-  Wire.write((byte)val);
-  Wire.endTransmission();
+  _wire->beginTransmission(DRV2605_ADDR);
+  _wire->write((byte)reg);
+  _wire->write((byte)val);
+  _wire->endTransmission();
 }
 
 /**************************************************************************/

--- a/Adafruit_DRV2605.cpp
+++ b/Adafruit_DRV2605.cpp
@@ -53,19 +53,8 @@ Adafruit_DRV2605::Adafruit_DRV2605() {
 
 /**************************************************************************/
 /*!
-  @brief Setup HW using the default Wire
-  @return Return value from init()
-*/
-/**************************************************************************/
-boolean Adafruit_DRV2605::begin() {
-  _wire = &Wire;
-  return init();
-}
-
-/**************************************************************************/
-/*!
-  @brief Setup HW using a different Wire
-  @param theWire Pointer to a TwoWire object
+  @brief Setup HW using a specified Wire
+  @param theWire Pointer to a TwoWire object, defaults to &Wire
   @return Return value from init()
 */
 /**************************************************************************/

--- a/Adafruit_DRV2605.h
+++ b/Adafruit_DRV2605.h
@@ -81,8 +81,7 @@
 class Adafruit_DRV2605 {
   public:
     Adafruit_DRV2605(void);
-    boolean begin(void);
-    boolean begin(TwoWire *theWire);
+    boolean begin(TwoWire *theWire = &Wire);
 
     boolean init();
     void writeRegister8(uint8_t reg, uint8_t val);

--- a/Adafruit_DRV2605.h
+++ b/Adafruit_DRV2605.h
@@ -82,7 +82,9 @@ class Adafruit_DRV2605 {
   public:
     Adafruit_DRV2605(void);
     boolean begin(void);
+    boolean begin(TwoWire *theWire);
 
+    boolean init();
     void writeRegister8(uint8_t reg, uint8_t val);
     uint8_t readRegister8(uint8_t reg);
     void setWaveform(uint8_t slot, uint8_t w);
@@ -97,5 +99,5 @@ class Adafruit_DRV2605 {
     void useLRA();
 
   private:
-
+    TwoWire *_wire;
 };


### PR DESCRIPTION
This adds the option to specify the TwoWire object for boards that have more than one I2C interface.
