### PR TITLE
Add option to not run begin() for wire object

### DIFF
--- a/Adafruit_DRV2605.cpp
+++ b/Adafruit_DRV2605.cpp
@@ -55,11 +55,15 @@ Adafruit_DRV2605::Adafruit_DRV2605() {
 /*!
   @brief Setup HW using a specified Wire
   @param theWire Pointer to a TwoWire object, defaults to &Wire
+  @param runBegin Run begin() or not, useful when using non-standard i2c pins
   @return Return value from init()
 */
 /**************************************************************************/
-boolean Adafruit_DRV2605::begin(TwoWire *theWire) {
+boolean Adafruit_DRV2605::begin(TwoWire *theWire, boolean runBegin) {
   _wire = theWire;
+  if (runBegin) {
+    _wire->begin();
+  }
   return init();
 }
 
@@ -70,7 +74,6 @@ boolean Adafruit_DRV2605::begin(TwoWire *theWire) {
 */
 /**************************************************************************/
 boolean Adafruit_DRV2605::init() {
-  _wire->begin();
   uint8_t id = readRegister8(DRV2605_REG_STATUS);
   //Serial.print("Status 0x"); Serial.println(id, HEX);
 

--- a/Adafruit_DRV2605.h
+++ b/Adafruit_DRV2605.h
@@ -81,7 +81,7 @@
 class Adafruit_DRV2605 {
   public:
     Adafruit_DRV2605(void);
-    boolean begin(TwoWire *theWire = &Wire);
+    boolean begin(TwoWire *theWire = &Wire, boolean runBegin = true);
 
     boolean init();
     void writeRegister8(uint8_t reg, uint8_t val);


### PR DESCRIPTION
Fixes issue noted in #10. 

The library would run `_wire->begin()` on its own in init(), so if any arguments were needed (for alternate I2C pins on ESP32, for example) or if begin() needed to be run before some other things (for SAMD21 alt pins) it would interfere or run a second time and crash.

Added a second argument to begin() which defaults to true. If true it runs `_wire->begin()`, false and it skips that call, leaving it up to the developer to initialize the wire first. We could just remove the call altogether but that would break existing code.

Tested on Feather M0 and Huzzah32 with defaults and assigning different I2C pins.
