### PR TITLE
Use signed RTP value

### DIFF
--- a/Adafruit_DRV2605.cpp
+++ b/Adafruit_DRV2605.cpp
@@ -168,11 +168,19 @@ void Adafruit_DRV2605::setMode(uint8_t mode) {
 /*!
   @brief Set the realtime value when in RTP mode, used to directly drive the
   haptic motor.
-  @param rtp 8-bit drive value.
+  @param rtp 8-bit signed drive value
+
+    drive value | output voltage | vibration intensity
+    -128        | -V             | 100%
+    0           | 0              | 0%
+    127         | V              | 100%
+
+  See Figure 24 in the datasheet for more details:
+    http://www.adafruit.com/datasheets/DRV2605.pdf
 */
 /**************************************************************************/
-void Adafruit_DRV2605::setRealtimeValue(uint8_t rtp) {
-  writeRegister8(DRV2605_REG_RTPIN, rtp);
+void Adafruit_DRV2605::setRealtimeValue(int8_t rtp) {
+  writeRegister8(DRV2605_REG_RTPIN, (uint8_t)rtp);
 }
 
 /**************************************************************************/

--- a/Adafruit_DRV2605.h
+++ b/Adafruit_DRV2605.h
@@ -100,7 +100,7 @@ public:
   void go(void);
   void stop(void);
   void setMode(uint8_t mode);
-  void setRealtimeValue(uint8_t rtp);
+  void setRealtimeValue(int8_t rtp);
   // Select ERM (Eccentric Rotating Mass) or LRA (Linear Resonant Actuator)
   // vibration motor The default is ERM, which is more common
   void useERM();


### PR DESCRIPTION
Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

  Change from `uint8_t` to `int8_t` for setting the RTP value. Also added more
documentation for the `setRealtimeValue` function. This will make the range of 
the drive value clearer (somewhat clarifies the question in #17).

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

  No added limitation

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

  No logical changes. Mostly documentation change.

Thank you again for contributing!  We will try to test and integrate the change
as soon as we can, but be aware we have many GitHub repositories to manage and
can't immediately respond to every request.  There is no need to bump or check in
on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated--sometimes the
priorities of Adafruit's GitHub code (education, ease of use) might not match the
priorities of the pull request.  Don't fret, the open source community thrives on
forks and GitHub makes it easy to keep your changes in a forked repo.

After reviewing the guidelines above you can delete this text from the pull request.
